### PR TITLE
Hash implementation for Redshift adapter

### DIFF
--- a/macros/utils/docs/helpers.yml
+++ b/macros/utils/docs/helpers.yml
@@ -24,6 +24,9 @@ macros:
   - name: bigquery__simple_hash
     docs:
       show: false
+  - name: redshift__simple_hash
+    docs:
+      show: false
   - name: postgres__simple_hash
     docs:
       show: false

--- a/macros/utils/simple_hash.sql
+++ b/macros/utils/simple_hash.sql
@@ -11,6 +11,10 @@ sha2( ({{ expr }})::varchar, {{ digest_size }})
 encode(sha{{ digest_size }} ( ({{ expr }})::varchar::bytea), 'hex')
 {%- endmacro -%}
 
+{%- macro redshift__simple_hash(expr, digest_size=256) -%}
+sha2( ({{ expr }})::varchar, {{ digest_size }})
+{%- endmacro -%}
+
 {%- macro bigquery__simple_hash(expr, digest_size=256) -%}
 {{- dbt_privacy.raise_on_bad_digest_size(digest_size, ok_sizes=[256, 512]) -}}
 to_hex(sha{{ digest_size }} (cast({{ expr }} as string)))


### PR DESCRIPTION
The `simple_hash` macro (called by the `hash` macro) fails on Redshift because the Redshift adapter inherits from the Postgres implementation.

For example
```
select {{ dbt_privacy.hash('test') }}
```
compiles to
```
select encode(sha256 ( ('' || lower(test) || encode(sha256 (...)::varchar::bytea), 'hex'))::varchar::bytea), 'hex')
```
But both `encode` and `sha256` functions are unknown to Redshift.

This proposal just repeats the default behaviour under the macro `redshift__simple_hash` to avoid inheriting the Postgres behaviour. Compiled example after change:
```
select sha2( ('' || lower(test) || sha2( (...)::varchar, 256))::varchar, 256)
```